### PR TITLE
Remove libosinfo bits

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -477,8 +477,6 @@ dnl was 2.36, can we drop this to 2.14 to allow for Debian 7.0
 dnl 9/2017: need >= 2.32 for g_thread_...() functions
 PKG_CHECK_MODULES(GLIB,  glib-2.0 >= 2.32) 
 required_packages="$required_packages glib-2.0 >= 2.32"
-dnl Not currently used
-dnl PKG_CHECK_MODULES(OSINFO, libosinfo-1.0 >= 0.1, [libosinfo_found=yes], [libosinfo_found=no])
 
 PKG_CHECK_MODULES(UDEV,   libudev, 
      [libudev_found=1],  

--- a/src/util/device_id_util.c
+++ b/src/util/device_id_util.c
@@ -62,7 +62,6 @@ char * devid_find_file(Device_Id_Type id_type) {
    bool debug = false;
 
    char * known_pci_ids_dirs[] = {
-         "/usr/share/libosinfo/db",
          "/usr/share",
          "/usr/share/misc",
          "/usr/share/hwdata",


### PR DESCRIPTION
Remove the references to (private) libosinfo things, also because libosinfo is not actually used.