### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ddcutil
 brightness and color levels.
 
 Most monitors, other than laptop displays, have a Virtual Control Panel (VCP), 
-which implements features defined in the Montor Control Command Set (MCCS).
+which implements features defined in the Monitor Control Command Set (MCCS).
 Typically, **ddcutil** communicates with the monitor's VCP over an I2C bus, as per 
 the Display Data Channel/Command Interface Standard (DDC/CI).
 

--- a/src/util/util.md
+++ b/src/util/util.md
@@ -1,6 +1,6 @@
 /** \dir
 
-Direcory util provides services that are independent of **ddcutil** and could be used in other applications.
+Directory util provides services that are independent of **ddcutil** and could be used in other applications.
 
 Most files provide general purpose functions such as data structures, and output management. 
 


### PR DESCRIPTION
Fixed a couple typos.

I also saw one on the online documentation but I don't know where those files are or how they are generated so I have not been able to edit those. 
https://www.ddcutil.com/udf/ in the section "User Defined Feature File"
> The MCCS specification has **evoloved** include features that don't neatly conform the original Continous/Non-Continuous classification.

evoloved -> evolved to