### PR TITLE
Fix missing header and declaration after goto

### DIFF
--- a/src/i2c/i2c_edid.c
+++ b/src/i2c/i2c_edid.c
@@ -359,10 +359,8 @@ i2c_get_raw_edid_by_fd(int fd, Buffer * rawedid)
 
    int max_tries = (EDID_Read_Size == 0) ?  4 : 2;
    DBGTRC_NOPREFIX(debug, TRACE_GROUP, "EDID_Read_Size=%d, max_tries=%d", EDID_Read_Size, max_tries);
-   I2C_IO_Strategy_Id cur_strategy_id = I2C_IO_STRATEGY_NOT_SET;
-retry:
-   cur_strategy_id = i2c_get_io_strategy_id();
-   assert(cur_strategy_id != I2C_IO_STRATEGY_NOT_SET);
+retry: ;
+   I2C_IO_Strategy_Id cur_strategy_id = i2c_get_io_strategy_id();
    DBGMSF(debug, "Using strategy  %s", i2c_io_strategy_id_name(cur_strategy_id) );
    int rc = -1;
    bool read_bytewise = EDID_Read_Bytewise;

--- a/src/i2c/i2c_strategy_dispatcher.c
+++ b/src/i2c/i2c_strategy_dispatcher.c
@@ -8,6 +8,7 @@
 
 /** \cond */
 #include <assert.h>
+#include <errno.h>
 #include <stdio.h>
 #include <syslog.h>
 /** \endcond */
@@ -180,7 +181,7 @@ Status_Errno_DDC invoke_i2c_writer(
                  bytes_to_write,
                  hexstring_t(bytes_to_write, bytect));
 
-retry:
+retry: ;
    I2C_IO_Strategy * strategy = i2c_get_io_strategy();
    DBGTRC_NOPREFIX(debug, TRACE_GROUP, "strategy = %s", strategy->strategy_name);
    Status_Errno_DDC rc = strategy->i2c_writer(fd, slave_address, bytect, bytes_to_write);
@@ -225,7 +226,7 @@ Status_Errno_DDC invoke_i2c_reader(
                    sbool(read_bytewise),
                    readbuf);
 
-retry:
+retry: ;
      I2C_IO_Strategy * strategy = i2c_get_io_strategy();
      DBGTRC_NOPREFIX(debug, TRACE_GROUP, "strategy = %s", strategy->strategy_name);
      Status_Errno_DDC rc = strategy->i2c_reader(fd, slave_address, read_bytewise, bytect, readbuf);


### PR DESCRIPTION
gcc < 11 complains "[goto] label can only be part of a statement and a declaration is not a statement" and and clang gets
completely confused: "expected expression"

---

gcc 11 and newer seems to be completely ok with declarations after labels.