### PR TITLE
60-ddcutil.rules: fix warning reported by udevadm verify

### DIFF
--- a/data/usr/lib/udev/rules.d/60-ddcutil.rules
+++ b/data/usr/lib/udev/rules.d/60-ddcutil.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="i2c-dev",KERNEL=="i2c-[0-9]*", ATTRS{class}=="0x030000", TAG+="uaccess" 
+SUBSYSTEM=="i2c-dev", KERNEL=="i2c-[0-9]*", ATTRS{class}=="0x030000", TAG+="uaccess"


### PR DESCRIPTION
Fix the following warning reported by udevadm verify:

```
data/usr/lib/udev/rules.d/60-ddcutil.rules:1 Whitespace after comma is expected.
data/usr/lib/udev/rules.d/60-ddcutil.rules: udev rules check failed
```