### PR TITLE
i2c_check_bus: remove redundant assertion

### DIFF
--- a/src/i2c/i2c_bus_core.c
+++ b/src/i2c/i2c_bus_core.c
@@ -611,7 +611,6 @@ void i2c_check_bus(I2C_Bus_Info * bus_info) {
            (bus_info->flags & I2C_BUS_VALID_NAME_CHECKED) &&
            (bus_info->flags & I2C_BUS_HAS_VALID_NAME)
          );
-   assert(sys_drm_connectors);
 
    if (!(bus_info->flags & I2C_BUS_PROBED)) {
       DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "Probing");


### PR DESCRIPTION
The sys_drm_connectors variable is initialized inside get_drm_connector_name_by_busno by a call to find_sys_drm_connector .

Related: https://github.com/rockowitz/ddcutil/issues/365#ref-issue-2086718957

I also tested with powerdevil. I have taken PKGBUILD for ddcutil-git package and compiled for my archlinux for master branch. The following reproduces the error:

```
$ pacman -U ddcutil-git-2.1.0.r7.g443330a2-1-x86_64.pkg.tar.zst
$ killall org_kde_powerdevil
$ kstart5 /usr/lib/org_kde_powerdevil
....
org.kde.powerdevil: org.kde.powerdevil.backlighthelper.brightness failed
org_kde_powerdevil: i2c_bus_core.c:614: i2c_check_bus: Assertion `sys_drm_connectors' failed.
```

I then build ddcutil-git with this patch. It fixes the powerdevil:

```
$ pacman -U ddcutil-git-2.1.0.r8.g23fe50b2-1-x86_64.pkg.tar.zst
$ killall org_kde_powerdevil
$ kstart5 /usr/lib/org_kde_powerdevil
Omitting both --window and --windowclass arguments is not recommended
org.kde.powerdevil: org.kde.powerdevil.chargethresholdhelper.getthreshold failed "Charge thresholds are not supported by the kernel for this hardware"
org.kde.powerdevil: org.kde.powerdevil.backlighthelper.brightness failed
/* no crash */
```