### PR TITLE
typo in manpage

### DIFF
--- a/man/ddcutil.1
+++ b/man/ddcutil.1
@@ -426,7 +426,7 @@ Identify all attached monitors.
 Show all settings that the default monitor supports and that \fBddcutil\fP understands.
 .PP
 .sp 0
-.B ddctpp getvcp 10 --display 2
+.B ddcutil getvcp 10 --display 2
 .br
 Query the luminosity value of the second monitor. 
 


### PR DESCRIPTION
I `grepped` for ddctpp and the manpages were the only place I could find it, so I assume it's a typo. 