### PR TITLE
Fix build with -Werror=format-security and GCC 14.2.1

### DIFF
--- a/src/base/display_lock.c
+++ b/src/base/display_lock.c
@@ -242,7 +242,7 @@ lock_display2(
       g_snprintf(buf, 80,
             "Attempting to lock device %s already locked by current thread %jd",
             dpath_repr_t(&dlr->io_path), get_thread_id());
-      MSG_W_SYSLOG(DDCA_SYSLOG_ERROR, buf);
+      MSG_W_SYSLOG(DDCA_SYSLOG_ERROR, "%s", buf);
       err = ERRINFO_NEW(DDCRC_ALREADY_OPEN, buf);
       goto bye;
    }
@@ -366,7 +366,7 @@ unlock_display2(Display_Lock_Record * dlr) {
          g_snprintf(buf, 80, "Attempting to unlock device %s locked by different thread %jd",
                     dpath_repr_t(&dlr->io_path), lock_tid);
       }
-      SYSLOG2(DDCA_SYSLOG_ERROR, buf);
+      SYSLOG2(DDCA_SYSLOG_ERROR, "%s", buf);
       err = ERRINFO_NEW(DDCRC_LOCKED, buf);
    }
    else {

--- a/src/base/i2c_bus_base.c
+++ b/src/base/i2c_bus_base.c
@@ -328,7 +328,7 @@ void i2c_free_bus_info(I2C_Bus_Info * businfo) {
                businfo->busno, businfo->edid, hexstring_t((Byte*) businfo->marker,4));
          DBGTRC_NOPREFIX(debug, TRACE_GROUP,  "%s", msg);
          if (IS_DBGTRC(debug, TRACE_GROUP))
-            SYSLOG2(DDCA_SYSLOG_DEBUG, msg);
+            SYSLOG2(DDCA_SYSLOG_DEBUG, "%s", msg);
          free_parsed_edid(businfo->edid);
          businfo->edid = NULL;
       }


### PR DESCRIPTION
Error snippet:

```
display_lock.c:245:39: error: format not a string literal and no format arguments [-Werror=format-security]
  245 |       MSG_W_SYSLOG(DDCA_SYSLOG_ERROR, buf);
      |                                       ^~~
../../src/base/core.h:603:18: note: in definition of macro 'MSG_W_SYSLOG'
  603 |       fprintf(f, format, ##__VA_ARGS__); \
      |                  ^~~~~~
```