### PR TITLE
dw_free_watch_displays_data(): fix XDisplay leak

### DIFF
--- a/src/dw/dw_common.c
+++ b/src/dw/dw_common.c
@@ -135,7 +135,7 @@ void dw_free_watch_displays_data(Watch_Displays_Data * wdd) {
       assert( memcmp(wdd->marker, WATCH_DISPLAYS_DATA_MARKER, 4) == 0 );
       wdd->marker[3] = 'x';
 #ifdef USE_X11
-      free(wdd->evdata);
+      dw_free_xevent_data(wdd->evdata);
 #endif
       free(wdd);
    }


### PR DESCRIPTION
I started investigating because I stopped being able to open multiple XWayland apps after a few weeks of uptime and normal usage. Powerdevil was leaking XDisplay handles due to its usage of ddcutil, because the `XEvent_Data` struct inside `Watch_Displays_Data` was not properly freed. As a result, the number of open X connections kept increasing over time, reaching 235 on my system, and opening a couple of X apps got me 'Maximum number of clients reached' errors. This PR should fix the leak.

To reproduce the leak: disconnect and reconnect a display a couple of times with powerdevil running, and observe the number of X connections increase.
The command I've used to print the number of X connections per process (run as root, source: https://unix.stackexchange.com/a/700637):
```
ss -x src "*/tmp/.X11-unix/*" | grep -Eo "[0-9]+\s*$" | while read port; do ss -p -x | grep -w $port | grep -v X11-unix; done | grep -Eo '".+"' | sort | uniq -c | sort -rn
```

I've reported this to KDE first, here, before I've figured out the culprit: https://bugs.kde.org/show_bug.cgi?id=503244

This issue is a regression in 2.2.0