### PR TITLE
Fix "groff-message troff:<standard input>:281: warning: macro '/"' not defined".

### DIFF
--- a/man/ddcutil.1
+++ b/man/ddcutil.1
@@ -278,15 +278,15 @@ Like \fB--vstats\fP, but includes additional internal information.
 .BI --syslog " [" debug | verbose | info | notice | warn | error | never " ]"
 Write messages of the specified or more urgent severity level to the system log.
 The \fBddcutil\fP default is \fBWARN\fP. The \fBlibddcutil\P default is \fBNOTICE\fP.
-./" .TQ
-./" .BI "--libddcutil-trace-file" file name
-./" Direct trace output to the specified file instead of the terminal. This is a \fBlibddcutil\fP only option.
-./" .TQ
-./" .BI "--trace" trace-class-name
-./" Trace all functions in a trace class.  For a list of trace classes, use \fI--help --verbose\fP.
-./" .TQ
-./" .BI "--trcfunc" function-name
-./" Trace a specific function.
+.\" .TQ
+.\" .BI "--libddcutil-trace-file" file name
+.\" Direct trace output to the specified file instead of the terminal. This is a \fBlibddcutil\fP only option.
+.\" .TQ
+.\" .BI "--trace" trace-class-name
+.\" Trace all functions in a trace class.  For a list of trace classes, use \fI--help --verbose\fP.
+.\" .TQ
+.\" .BI "--trcfunc" function-name
+.\" Trace a specific function.
 
 
 .PP


### PR DESCRIPTION
Fix "groff-message troff:<standard input>:281: warning: macro '/"' not defined".

From Debians lintian:

```
W: ddcutil: groff-message troff:<standard input>:281: warning: macro '/"' not defined [usr/share/man/man1/ddcutil.1.gz:1]
N: 
N:   A manual page provoked warnings or errors from the man program. Here are
N:   some common ones:
N:   
N:   "cannot adjust" or "can't break" are issues with paragraph filling. They
N:   are usually related to long lines. Justifying text on the left hand side
N:   can help with adjustments. Hyphenation can help with breaks.
N:   
N:   For more information, please see "Manipulating Filling and Adjusting" and
N:   "Manipulating Hyphenation" in the Groff manual (see info groff).
N:   
N:   "can't find numbered character" usually means that the input was in a
N:   national legacy encoding. The warning means that some characters were
N:   dropped. Please use escapes such as \[:a] as described on the groff_char
N:   manual page.
N:   
N:   Other common warnings are formatting typos. String arguments to .IP
N:   require quotes. Usually, some text is lost or mangled. See the groff_man
N:   (or groff_mdoc if using mdoc) manual page for details on macros.
N:   
N:   The check for manual pages uses the --warnings option to man to catch
N:   common problems, like a . or a ' at the beginning of a line as literal
N:   text. They are interpreted as Groff commands. Just reformat the paragraph
N:   so the characters are not at the beginning of a line. You can also add a
N:   zero-width space (\&) in front of them.
N:   
N:   Aside from overrides, warnings can be disabled with the .warn directive.
N:   Please see "Debugging" in the Groff manual.
N:   
N:   You can see the warnings yourself by running the command used by Lintian:
N:   
N:       LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
N:           man --warnings -E UTF-8 -l -Tutf8 -Z <file> >/dev/null
N: 
N:   Please refer to the groff_man(7) manual page and the groff_mdoc(7) manual
N:   page for details.
N: 
N:   Visibility: warning
N:   Show-Always: no
N:   Check: documentation/manual
N:   Renamed from: manpage-has-errors-from-man
```
