### PR TITLE
Ignore i915/xe i2c on Modern Standby platforms

### DIFF
--- a/src/sysfs/sysfs_base.c
+++ b/src/sysfs/sysfs_base.c
@@ -1426,6 +1426,14 @@ ignorable_i2c_device_sysfs_name(const char * name, const char * driver) {
          }
       }
    }
+   char * mem_sleep = file_get_first_line("/sys/power/mem_sleep", false);
+   if (mem_sleep) {
+      if (strstr(mem_sleep, "[s2idle]") && (streq(driver, "i915") || streq(driver, "xe"))) {
+         // Accessing i2c on Modern Standby platforms with Intel graphics may break s0ix
+         result = true;
+      }
+      free(mem_sleep);
+   }
    // printf("(%s) name=|%s|, driver=|%s|, returning: %s\n", __func__, name, driver, sbool(result));
    return result;
 }


### PR DESCRIPTION
Fixes https://github.com/rockowitz/ddcutil/issues/429

Testing:
```
# echo 1 > /sys/module/intel_pmc_core/parameters/warn_on_s0ix_failures
# ddcutil detect
# systemctl suspend
# dmesg | grep "CPU did not enter SLP_S0"
```