### PR TITLE
Fix out-of-tree build

### DIFF
--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS =         \
   $(LIBDRM_CFLAGS)    \
   $(GLIB_CFLAGS)      \
   -I$(top_srcdir)/src \
+  -I$(top_builddir)/src \
   -I$(top_srcdir)/src/public
 
 AM_CFLAGS = $(AM_CFLAGS_STD)


### PR DESCRIPTION
Building ddcutil with an out-of-tree configuration currently fails because of a missing include file:

| ../../../git/src/base/build_timestamp.c:11:10: fatal error: base/build_details.h: No such file or directory
|    11 | #include "base/build_details.h"       // created by Makefile
|       |          ^~~~~~~~~~~~~~~~~~~~~~
| compilation terminated.

I observed this while upgrading the ddcutil yocto recipe [1] from 2.1.4 to 2.2.1. A simple fix is to add the $(top_builddir)/src include directory.

1: https://github.com/KDE/yocto-meta-kde/blob/master/recipes-support/ddcutil_git.bb