### PR TITLE
Fix path in query_drm_using_sysfs during interrogate

### DIFF
--- a/src/app_sysenv/query_sysenv_sysfs.c
+++ b/src/app_sysenv/query_sysenv_sysfs.c
@@ -757,7 +757,7 @@ void query_drm_using_sysfs() {
    int depth = 1;
    int d0 = depth;
    rpt_nl();
-   char * dname = SYS"/sys/class/drm";
+   char * dname = SYS"/class/drm";
 
    rpt_vstring(d0, "*** Examining %s ***", dname);
    dir_filtered_ordered_foreach(


### PR DESCRIPTION
This PR Fixes the following error:

> *** Examining /sys/sys/class/drm ***
> Unable to open directory /sys/sys/class/drm: No such file or directory

This regression was introduced in 2.2.1.