### PR TITLE
fix: handle null ptr in dw_deinit_xevent_screen_change_notification

### DIFF
--- a/src/dw/dw_xevent.c
+++ b/src/dw/dw_xevent.c
@@ -36,7 +36,7 @@ void  dw_dbgrpt_xevent_data(XEvent_Data* evdata, int depth) {
 
 
 void dw_deinit_xevent_screen_change_notification(XEvent_Data * evdata) {
-   if (evdata->dpy)
+   if (evdata && evdata->dpy)
       XCloseDisplay(evdata->dpy);
    free(evdata);
 }


### PR DESCRIPTION
This prevents a segfault or other UB if a null pointer is passed to `dw_deinit_xevent_screen_change_notification`. (I observed such a segfault on my system in Plasma Powerdevil (which depends on ddcutil), with a stack trace pointing to this code; I haven't tracked down the ultimate cause but I think it has something to do with KDE Plasma being run with Xwayland disabled, meaning there's no X11 session.)