### PR TITLE
 Fix build with glibc 2.43 

### DIFF
--- a/src/base/displays.c
+++ b/src/base/displays.c
@@ -1623,7 +1623,7 @@ void free_display_handle(Display_Handle * dh) {
  *  \param   hiddev_name device name
  *  \return  device number, -1 if error
  */
-int hiddev_name_to_number(const char * hiddev_name) {
+int hiddev_name_to_number(char * hiddev_name) {
    assert(hiddev_name);
    char * p = strstr(hiddev_name, "hiddev");
 

--- a/src/base/displays.h
+++ b/src/base/displays.h
@@ -297,7 +297,7 @@ void             free_display_handle(Display_Handle * dh);
 //* Option flags for display selection functions */
 typedef Byte Display_Selection_Options;
 
-int    hiddev_name_to_number(const char * hiddev_name);
+int    hiddev_name_to_number(char * hiddev_name);
 #ifdef UNUSED
 char * hiddev_number_to_name(int hiddev_number);
 #endif

--- a/src/util/file_util.c
+++ b/src/util/file_util.c
@@ -883,7 +883,7 @@ void filter_and_limit_g_ptr_array(
  *  https://stackoverflow.com/questions/7430248/creating-a-new-directory-in-c
  */
 int rek_mkdir(
-      const char *path,
+      char *path,
       FILE *      ferr)
 {
    bool debug = false;
@@ -935,7 +935,7 @@ int fopen_mkdir(
 
    int rc = 0;
    *fp_loc = NULL;
-   char *sep = strrchr(path, '/');
+   const char *sep = strrchr(path, '/');
    if (sep) {
       char *path0 = g_strdup(path);
       path0[ sep - path ] = 0;

--- a/src/util/file_util.h
+++ b/src/util/file_util.h
@@ -155,7 +155,7 @@ int read_file_with_filter(
       bool         free_strings);
 
 int rek_mkdir(
-      const char * path,
+      char * path,
       FILE *       ferr);
 
 int fopen_mkdir(

--- a/src/util/i2c_util.c
+++ b/src/util/i2c_util.c
@@ -60,7 +60,7 @@ int extract_number_after_hyphen(const char * name) {
    int result = -1;
 
    if (name) {
-      char * hyphen = strchr(name, '-');
+      const char * hyphen = strchr(name, '-');
       if (hyphen && *(hyphen+1) != '\0') {
          int ival;
          if ( str_to_int(hyphen+1, &ival, 10) )

--- a/src/util/sysfs_filter_functions.c
+++ b/src/util/sysfs_filter_functions.c
@@ -183,7 +183,7 @@ bool predicate_exact_D_00hh(const char * value, const char * sbusno) {
    bool b1 = compile_and_eval_regex(D_00hh_pattern, value);
    if (b1) {
       // our utilities don't support extracting match groups
-      char * hypos = strchr(value, '-'); // must succeed because of regex match
+      const char * hypos = strchr(value, '-'); // must succeed because of regex match
       char * s = substr(value, 0, (hypos-value));
       b1 = streq(s, sbusno);
       free(s);


### PR DESCRIPTION
From the glibc 2.43 release notes:

> In C23, for many functions a _Generic macro propagating the constness of a pointer parameter to the returned pointer has been added. This glibc release has implemented the change with C23 or _GNU_SOURCE enabled (i.e. -std=gnu17 won't fix everything). The change is expected to break some packages as (1) they assume the returned pointer is non-const or (2) they re-declare one of those functions without wrapping the function identifier in parentheses.

> For (1), the best fix is correctly retaining the constness when handling the returned pointer. If it's too difficult and you are pretty sure the code won't write through the returned pointer, you may also cast the constness away. For (2), simply add the parentheses. #undefing those macros can be used as a last resort.