### PR TITLE
Loosen the video display adapter test, check only if the first byte of the adapter class is x03.

### DIFF
--- a/data/etc/udev/rules.d/60-ddcutil-i2c.rules
+++ b/data/etc/udev/rules.d/60-ddcutil-i2c.rules
@@ -8,7 +8,7 @@
 
 # The usual case, using TAG+="uaccess":  If a /dev/i2c device is associated
 # with a video adapter, grant the current user access to it.
-# SUBSYSTEM=="i2c-dev", KERNEL=="i2c-[0-9]*", ATTRS{class}=="0x030000", TAG+="uaccess" 
+# SUBSYSTEM=="i2c-dev", KERNEL=="i2c-[0-9]*", ATTRS{class}=="0x03*", TAG+="uaccess" 
 
 # Assigns i2c devices to group i2c, and gives that group RW access.
 # Individual users must then be assigned to group i2c.


### PR DESCRIPTION
A AMD Ryzen AI 9 365 based system returns 0x038000 as the adapter class.

This patch to the 60-ddcutil-i2c.rules example file is meant to reflect the change to the installed version, made in aa29e87.

Partially addresses issue #530