### PR TITLE
fix: log initial_stabilization_millisec instead of extra_stabilization_millisec

### DIFF
--- a/src/dw/dw_common.c
+++ b/src/dw/dw_common.c
@@ -552,7 +552,7 @@ ddc_i2c_stabilized_buses(GPtrArray* prior, bool some_displays_disconnected) {
 Bit_Set_256
 dw_stabilized_buses_bs(Bit_Set_256 bs_prior, bool some_displays_disconnected) {
    bool debug = false;
-   DBGTRC_STARTING(debug, TRACE_GROUP, "prior =%s, some_displays_disconnected=%s, extra_stabilization_millisec=%d",
+   DBGTRC_STARTING(debug, TRACE_GROUP, "prior =%s, some_displays_disconnected=%s, initial_stabilization_millisec=%d",
          BS256_REPR(bs_prior), SBOOL(some_displays_disconnected), initial_stabilization_millisec);
    // DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "bs_prior:", BS256_REPR(bs_prior));
 

--- a/src/dw/dw_main.c
+++ b/src/dw/dw_main.c
@@ -252,7 +252,7 @@ dw_start_watch_displays(DDCA_Display_Event_Class event_classes) {
          "Watching for display connection changes, resolved watch mode = %s, poll loop interval = %d millisec",
          watch_mode_name(resolved_watch_mode), calculated_watch_loop_millisec);
    MSG_W_SYSLOG(DDCA_SYSLOG_NOTICE,
-         "                                         extra_stabilization_millisec: %d,  stabilization_poll_millisec: %d",
+         "                                         initial_stabilization_millisec: %d,  stabilization_poll_millisec: %d",
          initial_stabilization_millisec, stabilization_poll_millisec);
 
    g_mutex_lock(&watch_thread_mutex);


### PR DESCRIPTION
This renames extra_stabilization_millisec to initial_stabilization_millisec in log output, so that it matches the variable

>ddcutil noop --settings | grep -- "--i1:"
   Utility option --i1:          Extra millisec to wait after apparent display disconnect (default = 0)