### PR TITLE
fix: don't include execinfo.h on non-glibc Linux systems

### DIFF
--- a/src/util/linux_util.c
+++ b/src/util/linux_util.c
@@ -10,7 +10,9 @@
 
 /** \cond */
 #include <assert.h>
+#ifdef __GLIBC__
 #include <execinfo.h>      // for segv handler
+#endif
 #include <fcntl.h>
 #include <glib-2.0/glib.h>
 #include <inttypes.h>


### PR DESCRIPTION
execinfo.h is only provided by glibc while some distros use Musl libc for example.