### PR TITLE
Typo fixes

### DIFF
--- a/man/ddcutil.1
+++ b/man/ddcutil.1
@@ -296,7 +296,7 @@ Options that tune execution
 Enable or disable caching of capabilities strings, improving performance.
 The default is
 .B --enable-capabilities-cache
-.TQ
+.\" .TQ
 .\" .B "--enable-displays-cache, --disable-displays-cache"
 .\" Enable or disable caching of information about detected displays, improving performance.
 .\" The default is 

--- a/src/i2c/i2c_bus_core.c
+++ b/src/i2c/i2c_bus_core.c
@@ -206,7 +206,7 @@ static bool cur_user_has_group_i2c_perms(const char * filename) {
          }
          else {
             if (!is_file_group_acl_rw(filename)) {
-               SIMPLE_STD_SYSLOG(LOG_WARNING, "Group permissons on %s not RW",filename);
+               SIMPLE_STD_SYSLOG(LOG_WARNING, "Group permissions on %s not RW",filename);
             }
             else {
                has_group_perms = true;


### PR DESCRIPTION
Hi,

here are trivial fixes for a typo in log message and a warning in the man page.