### PR TITLE
Fix typo

### DIFF
--- a/src/libmain/api_base.c
+++ b/src/libmain/api_base.c
@@ -669,7 +669,7 @@ _ddca_terminate(void) {
          dw_stop_watch_displays(/*wait=*/ true, &active_classes);   // in case it was started
       DBGTRC_NOPREFIX(debug, DDCA_TRC_API, "After ddc_stop_watch_displays");
       // sleep(5); // still needed?
-#ifdef USE_DBUG
+#ifdef USE_DBUS
       ldbus_stop_sleep_watch_thread();
 #endif
       // terminate_dw_services(); // handled by terminate_ddc_services()


### PR DESCRIPTION
Commit 950c0ecf24b118461f8d163deb27ab93fb75ff1a added ifdefs for USE_DBUS but in one of those cases it actually added USE_DBUG.

Replace the 'G' with an 'S'.