### PR TITLE
do not ignore sysfs class being zero

### DIFF
--- a/src/sysfs/sysfs_base.c
+++ b/src/sysfs/sysfs_base.c
@@ -1484,9 +1484,7 @@ sysfs_is_ignorable_i2c_device(int busno) {
       if (!ignorable) {
          uint32_t class = get_i2c_device_sysfs_class(busno);
          DBGF(debug, "get_i2c_device_sysfs_class(%d) returned 0x%08x ", busno, class);
-         if (class == 0)
-            ignorable = true;
-         else {
+         if (class) {
             DBGF(debug, "   class = 0x%08x", class);
             uint32_t cl2 = class & 0xffff0000;
             DBGF(debug, "   cl2 = 0x%08x", cl2);


### PR DESCRIPTION
Since commit [1] an i2c bus gets ignored when no corresponding class file is found.

This causes platforms, where the i2c host controller is not connect via PCIe, to be ignored completely, even though the bus is still valid. This makes the ddcutil useless on those platforms.

The absence of such a file is not enough to tell whether a bus is valid or not. Partially revert commit [1], to avoid ignoring an i2c bus

[1] 3df4af0e ("add comments re invalid bus number in i2c_device_sysfs_class(), is_ignorable_i2c_device()")